### PR TITLE
Update example to winit 0.24 and redraw every frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ core-foundation = "0.9.1"
 
 [dev-dependencies]
 gl = "0.14.0"
-winit = "0.22.2"
+winit = "0.24"

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -13,8 +13,10 @@ fn main() {
 
     gl::load_with(|symbol| context.get_proc_address(symbol) as *const _);
 
+    let now = std::time::Instant::now();
+
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        *control_flow = ControlFlow::Poll;
 
         match event {
             winit::event::Event::WindowEvent {
@@ -23,11 +25,14 @@ fn main() {
             } => {
                 *control_flow = ControlFlow::Exit;
             }
+            winit::event::Event::MainEventsCleared => {
+                window.request_redraw();
+            }
             winit::event::Event::RedrawRequested(_) => {
                 context.make_current();
 
                 unsafe {
-                    gl::ClearColor(1.0, 0.0, 1.0, 1.0);
+                    gl::ClearColor(now.elapsed().as_secs_f32().sin() * 0.5 + 0.5, 0.0, 1.0, 1.0);
                     gl::Clear(gl::COLOR_BUFFER_BIT);
                 }
 


### PR DESCRIPTION
 - Update winit to 0.24, this makes the example compile on apple silicon
 - Make the window use changing clear color over time to make it clear that the GL context is constantly drawing