### PR TITLE
Add an SDL2 example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ core-foundation = "0.9.1"
 [dev-dependencies]
 gl = "0.14.0"
 winit = "0.24"
-sdl2 = { version = "0.34", features = ["raw-window-handle"] }
+sdl2 = { version = "0.34", features = ["raw-window-handle", "bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ core-foundation = "0.9.1"
 [dev-dependencies]
 gl = "0.14.0"
 winit = "0.24"
+sdl2 = { version = "0.34", features = ["raw-window-handle"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ core-foundation = "0.9.1"
 
 [dev-dependencies]
 gl = "0.14.0"
-winit = "0.22.2"
+winit = "0.24"

--- a/examples/sdl2.rs
+++ b/examples/sdl2.rs
@@ -1,0 +1,55 @@
+use raw_gl_context::{GlConfig, GlContext};
+use sdl2::event::Event;
+use sdl2::keyboard::Keycode;
+
+pub fn main() {
+    // Setup SDL
+    let sdl2_context = sdl2::init().expect("Failed to initialize sdl2");
+    let video_subsystem = sdl2_context
+        .video()
+        .expect("Failed to create sdl video subsystem");
+
+    // Create the window
+    let window = video_subsystem
+        .window("Rafx Demo", 900, 600)
+        .position_centered()
+        .allow_highdpi()
+        .resizable()
+        .build()
+        .expect("Failed to create window");
+
+    let mut event_pump = sdl2_context
+        .event_pump()
+        .expect("Could not create sdl event pump");
+
+    let gl_context = GlContext::create(&window, GlConfig::default()).unwrap();
+
+    gl_context.make_current();
+
+    gl::load_with(|symbol| gl_context.get_proc_address(symbol) as *const _);
+
+    let now = std::time::Instant::now();
+
+    'running: loop {
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit { .. } => break 'running,
+                Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => break 'running,
+                _ => {}
+            }
+        }
+
+        gl_context.make_current();
+
+        unsafe {
+            gl::ClearColor(now.elapsed().as_secs_f32().sin() * 0.5 + 0.5, 0.0, 1.0, 1.0);
+            gl::Clear(gl::COLOR_BUFFER_BIT);
+        }
+
+        gl_context.swap_buffers();
+        gl_context.make_not_current();
+    }
+}

--- a/examples/sdl2.rs
+++ b/examples/sdl2.rs
@@ -11,7 +11,7 @@ pub fn main() {
 
     // Create the window
     let window = video_subsystem
-        .window("Rafx Demo", 900, 600)
+        .window("SDL2 GL Example", 900, 600)
         .position_centered()
         .allow_highdpi()
         .resizable()

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -13,8 +13,10 @@ fn main() {
 
     gl::load_with(|symbol| context.get_proc_address(symbol) as *const _);
 
+    let now = std::time::Instant::now();
+
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        *control_flow = ControlFlow::Poll;
 
         match event {
             winit::event::Event::WindowEvent {
@@ -23,11 +25,14 @@ fn main() {
             } => {
                 *control_flow = ControlFlow::Exit;
             }
+            winit::event::Event::MainEventsCleared => {
+                window.request_redraw();
+            }
             winit::event::Event::RedrawRequested(_) => {
                 context.make_current();
 
                 unsafe {
-                    gl::ClearColor(1.0, 0.0, 1.0, 1.0);
+                    gl::ClearColor(now.elapsed().as_secs_f32().sin() * 0.5 + 0.5, 0.0, 1.0, 1.0);
                     gl::Clear(gl::COLOR_BUFFER_BIT);
                 }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -8,9 +8,9 @@ use cocoa::appkit::{
     NSOpenGLPFAColorSize, NSOpenGLPFADepthSize, NSOpenGLPFADoubleBuffer, NSOpenGLPFAMultisample,
     NSOpenGLPFAOpenGLProfile, NSOpenGLPFASampleBuffers, NSOpenGLPFASamples, NSOpenGLPFAStencilSize,
     NSOpenGLPixelFormat, NSOpenGLProfileVersion3_2Core, NSOpenGLProfileVersion4_1Core,
-    NSOpenGLProfileVersionLegacy, NSOpenGLView, NSView,
+    NSOpenGLProfileVersionLegacy,
 };
-use cocoa::base::{id, nil, YES};
+use cocoa::base::{id, nil};
 
 use core_foundation::base::TCFType;
 use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
@@ -19,9 +19,9 @@ use core_foundation::string::CFString;
 use objc::{msg_send, sel, sel_impl};
 
 use crate::{GlConfig, GlError, Profile};
+use cocoa::foundation::NSAutoreleasePool;
 
 pub struct GlContext {
-    view: id,
     context: id,
 }
 
@@ -84,28 +84,25 @@ impl GlContext {
                 return Err(GlError::CreationFailed);
             }
 
-            let view = NSOpenGLView::alloc(nil)
-                .initWithFrame_pixelFormat_(parent_view.frame(), pixel_format);
+            let gl_context =
+                NSOpenGLContext::alloc(nil).initWithFormat_shareContext_(pixel_format, nil);
 
-            if view == nil {
+            if gl_context == nil {
                 return Err(GlError::CreationFailed);
             }
 
-            let () = msg_send![view, retain];
-            NSOpenGLView::display_(view);
-            parent_view.addSubview_(view);
+            gl_context.setView_(parent_view);
 
-            let context: id = msg_send![view, openGLContext];
-            let () = msg_send![context, retain];
-
-            context.setValues_forParameter_(
+            gl_context.setValues_forParameter_(
                 &(config.vsync as i32),
                 NSOpenGLContextParameter::NSOpenGLCPSwapInterval,
             );
 
             let () = msg_send![pixel_format, release];
 
-            Ok(GlContext { view, context })
+            Ok(GlContext {
+                context: gl_context,
+            })
         }
     }
 
@@ -134,8 +131,9 @@ impl GlContext {
 
     pub fn swap_buffers(&self) {
         unsafe {
+            let pool = NSAutoreleasePool::new(nil);
             self.context.flushBuffer();
-            let () = msg_send![self.view, setNeedsDisplay: YES];
+            let _: () = msg_send![pool, release];
         }
     }
 }
@@ -144,7 +142,6 @@ impl Drop for GlContext {
     fn drop(&mut self) {
         unsafe {
             let () = msg_send![self.context, release];
-            let () = msg_send![self.view, release];
         }
     }
 }


### PR DESCRIPTION
This change adds an example that uses SDL2 instead of winit.

This works great for macOS but SDL2 requires extra steps to link in windows. I usually use the bundled feature of the SDL2 crate which compiles SDL2, but it's broken in the latest version of the crate. So you might not want to take this change as it is now. (dev-dependencies can't be optional unfortunately). We could set sdl2-sys to pull in version = 0.34.2 and use the bundled feature. That would probably work well but it does add build times.

This change includes the other PRs.