### PR TITLE
Add more error checking on X11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub enum Profile {
 pub enum GlError {
     InvalidWindowHandle,
     VersionNotSupported,
-    CreationFailed,
+    CreationFailed(platform::CreationFailedError),
 }
 
 pub struct GlContext {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -20,6 +20,7 @@ use objc::{msg_send, sel, sel_impl};
 
 use crate::{GlConfig, GlError, Profile};
 
+pub type CreationFailedError = ();
 pub struct GlContext {
     view: id,
     context: id,
@@ -80,14 +81,14 @@ impl GlContext {
         let pixel_format = NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attrs);
 
         if pixel_format == nil {
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         let view = NSOpenGLView::alloc(nil)
             .initWithFrame_pixelFormat_(parent_view.frame(), pixel_format);
 
         if view == nil {
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         view.setWantsBestResolutionOpenGLSurface_(YES);

--- a/src/win.rs
+++ b/src/win.rs
@@ -64,6 +64,7 @@ const WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB: i32 = 0x20A9;
 
 type WglSwapIntervalEXT = extern "system" fn(i32) -> i32;
 
+pub type CreationFailedError = ();
 pub struct GlContext {
     hwnd: HWND,
     hdc: HDC,
@@ -109,7 +110,7 @@ impl GlContext {
 
         let class = RegisterClassW(&wnd_class);
         if class == 0 {
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         let hwnd_tmp = CreateWindowExW(
@@ -128,7 +129,7 @@ impl GlContext {
         );
 
         if hwnd_tmp.is_null() {
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         let hdc_tmp = GetDC(hwnd_tmp);
@@ -153,7 +154,7 @@ impl GlContext {
             ReleaseDC(hwnd_tmp, hdc_tmp);
             UnregisterClassW(class as *const WCHAR, hinstance);
             DestroyWindow(hwnd_tmp);
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         wglMakeCurrent(hdc_tmp, hglrc_tmp);
@@ -260,7 +261,7 @@ impl GlContext {
             ctx_attribs.as_ptr(),
         );
         if hglrc == std::ptr::null_mut() {
-            return Err(GlError::CreationFailed);
+            return Err(GlError::CreationFailed(()));
         }
 
         let gl_library_name = CString::new("opengl32.dll").unwrap();

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -8,6 +8,23 @@ use x11::xlib;
 
 use crate::{GlConfig, GlError, Profile};
 
+mod errors;
+
+#[derive(Debug)]
+pub enum CreationFailedError {
+    InvalidFBConfig,
+    GetProcAddressFailed,
+    MakeCurrentFailed,
+    ContextCreationFailed,
+    X11Error(errors::XLibError)
+}
+
+impl From<errors::XLibError> for GlError {
+    fn from(e: errors::XLibError) -> Self {
+        GlError::CreationFailed(CreationFailedError::X11Error(e))
+    }
+}
+
 // See https://www.khronos.org/registry/OpenGL/extensions/ARB/GLX_ARB_create_context.txt
 
 type GlXCreateContextAttribsARB = unsafe extern "C" fn(
@@ -26,10 +43,6 @@ type GlXSwapIntervalEXT =
 // See https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt
 
 const GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB: i32 = 0x20B2;
-
-extern "C" fn err_handler(_dpy: *mut xlib::Display, _err: *mut xlib::XErrorEvent) -> i32 {
-    0
-}
 
 fn get_proc_address(symbol: &str) -> *const c_void {
     let symbol = CString::new(symbol).unwrap();
@@ -57,102 +70,133 @@ impl GlContext {
             return Err(GlError::InvalidWindowHandle);
         }
 
-        let prev_callback = xlib::XSetErrorHandler(Some(err_handler));
-
         let display = handle.display as *mut xlib::_XDisplay;
 
-        let screen = xlib::XDefaultScreen(display);
+        errors::XErrorHandler::handle(display, |error_handler| {
+            let screen = unsafe { xlib::XDefaultScreen(display) };
 
-        #[rustfmt::skip]
-        let fb_attribs = [
-            glx::GLX_X_RENDERABLE, 1,
-            glx::GLX_X_VISUAL_TYPE, glx::GLX_TRUE_COLOR,
-            glx::GLX_DRAWABLE_TYPE, glx::GLX_WINDOW_BIT,
-            glx::GLX_RENDER_TYPE, glx::GLX_RGBA_BIT,
-            glx::GLX_RED_SIZE, config.red_bits as i32,
-            glx::GLX_GREEN_SIZE, config.green_bits as i32,
-            glx::GLX_BLUE_SIZE, config.blue_bits as i32,
-            glx::GLX_ALPHA_SIZE, config.alpha_bits as i32,
-            glx::GLX_DEPTH_SIZE, config.depth_bits as i32,
-            glx::GLX_STENCIL_SIZE, config.stencil_bits as i32,
-            glx::GLX_DOUBLEBUFFER, config.double_buffer as i32,
-            glx::GLX_SAMPLE_BUFFERS, config.samples.is_some() as i32,
-            glx::GLX_SAMPLES, config.samples.unwrap_or(0) as i32,
-            GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB, config.srgb as i32,
-            0,
-        ];
+            #[rustfmt::skip]
+                let fb_attribs = [
+                glx::GLX_X_RENDERABLE, 1,
+                glx::GLX_X_VISUAL_TYPE, glx::GLX_TRUE_COLOR,
+                glx::GLX_DRAWABLE_TYPE, glx::GLX_WINDOW_BIT,
+                glx::GLX_RENDER_TYPE, glx::GLX_RGBA_BIT,
+                glx::GLX_RED_SIZE, config.red_bits as i32,
+                glx::GLX_GREEN_SIZE, config.green_bits as i32,
+                glx::GLX_BLUE_SIZE, config.blue_bits as i32,
+                glx::GLX_ALPHA_SIZE, config.alpha_bits as i32,
+                glx::GLX_DEPTH_SIZE, config.depth_bits as i32,
+                glx::GLX_STENCIL_SIZE, config.stencil_bits as i32,
+                glx::GLX_DOUBLEBUFFER, config.double_buffer as i32,
+                glx::GLX_SAMPLE_BUFFERS, config.samples.is_some() as i32,
+                glx::GLX_SAMPLES, config.samples.unwrap_or(0) as i32,
+                GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB, config.srgb as i32,
+                0,
+            ];
 
-        let mut n_configs = 0;
-        let fb_config = glx::glXChooseFBConfig(display, screen, fb_attribs.as_ptr(), &mut n_configs);
+            let mut n_configs = 0;
+            let fb_config =
+                unsafe { glx::glXChooseFBConfig(display, screen, fb_attribs.as_ptr(), &mut n_configs) };
 
-        if n_configs <= 0 {
-            return Err(GlError::CreationFailed);
-        }
+            error_handler.check()?;
 
-        #[allow(non_snake_case)]
-        let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = {
-            let addr = get_proc_address("glXCreateContextAttribsARB");
-            if addr.is_null() {
-                return Err(GlError::CreationFailed);
-            } else {
-                std::mem::transmute(addr)
+            if n_configs <= 0 {
+                return Err(GlError::CreationFailed(CreationFailedError::InvalidFBConfig));
             }
-        };
 
-        #[allow(non_snake_case)]
-        let glXSwapIntervalEXT: GlXSwapIntervalEXT = {
-            let addr = get_proc_address("glXSwapIntervalEXT");
-            if addr.is_null() {
-                return Err(GlError::CreationFailed);
-            } else {
-                std::mem::transmute(addr)
+            #[allow(non_snake_case)]
+                let glXCreateContextAttribsARB: GlXCreateContextAttribsARB = unsafe {
+                let addr = get_proc_address("glXCreateContextAttribsARB");
+                if addr.is_null() {
+                    return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
+                } else {
+                    std::mem::transmute(addr)
+                }
+            };
+
+            #[allow(non_snake_case)]
+                let glXSwapIntervalEXT: GlXSwapIntervalEXT = unsafe {
+                let addr = get_proc_address("glXSwapIntervalEXT");
+                if addr.is_null() {
+                    return Err(GlError::CreationFailed(CreationFailedError::GetProcAddressFailed));
+                } else {
+                    std::mem::transmute(addr)
+                }
+            };
+
+            error_handler.check()?;
+
+            let profile_mask = match config.profile {
+                Profile::Core => glx::arb::GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+                Profile::Compatibility => glx::arb::GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+            };
+
+            #[rustfmt::skip]
+                let ctx_attribs = [
+                glx::arb::GLX_CONTEXT_MAJOR_VERSION_ARB, config.version.0 as i32,
+                glx::arb::GLX_CONTEXT_MINOR_VERSION_ARB, config.version.1 as i32,
+                glx::arb::GLX_CONTEXT_PROFILE_MASK_ARB, profile_mask,
+                0,
+            ];
+
+            let context = unsafe {
+                glXCreateContextAttribsARB(
+                    display,
+                    *fb_config,
+                    std::ptr::null_mut(),
+                    1,
+                    ctx_attribs.as_ptr(),
+                )
+            };
+
+            error_handler.check()?;
+
+            if context.is_null() {
+                return Err(GlError::CreationFailed(CreationFailedError::ContextCreationFailed));
             }
-        };
 
-        let profile_mask = match config.profile {
-            Profile::Core => glx::arb::GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
-            Profile::Compatibility => glx::arb::GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
-        };
+            unsafe {
+                let res = glx::glXMakeCurrent(display, handle.window, context);
+                error_handler.check()?;
+                if res == 0 {
+                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
+                }
 
-        #[rustfmt::skip]
-        let ctx_attribs = [
-            glx::arb::GLX_CONTEXT_MAJOR_VERSION_ARB, config.version.0 as i32,
-            glx::arb::GLX_CONTEXT_MINOR_VERSION_ARB, config.version.1 as i32,
-            glx::arb::GLX_CONTEXT_PROFILE_MASK_ARB, profile_mask,
-            0,
-        ];
+                glXSwapIntervalEXT(display, handle.window, config.vsync as i32);
+                error_handler.check()?;
 
-        let context = glXCreateContextAttribsARB(
-            display,
-            *fb_config,
-            std::ptr::null_mut(),
-            1,
-            ctx_attribs.as_ptr(),
-        );
+                if glx::glXMakeCurrent(display, 0, std::ptr::null_mut()) == 0 {
+                    error_handler.check()?;
+                    return Err(GlError::CreationFailed(CreationFailedError::MakeCurrentFailed));
+                }
+            }
 
-        if context.is_null() {
-            return Err(GlError::CreationFailed);
-        }
-
-        glx::glXMakeCurrent(display, handle.window, context);
-        glXSwapIntervalEXT(display, handle.window, config.vsync as i32);
-        glx::glXMakeCurrent(display, 0, std::ptr::null_mut());
-
-        xlib::XSetErrorHandler(prev_callback);
-
-        Ok(GlContext {
-            window: handle.window,
-            display,
-            context,
+            Ok(GlContext {
+                window: handle.window,
+                display,
+                context,
+            })
         })
     }
 
     pub unsafe fn make_current(&self) {
-        glx::glXMakeCurrent(self.display, self.window, self.context);
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            let res = glx::glXMakeCurrent(self.display, self.window, self.context);
+            error_handler.check().unwrap();
+            if res == 0 {
+                panic!("make_current failed")
+            }
+        })
     }
 
     pub unsafe fn make_not_current(&self) {
-        glx::glXMakeCurrent(self.display, 0, std::ptr::null_mut());
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            let res = glx::glXMakeCurrent(self.display, 0, std::ptr::null_mut());
+            error_handler.check().unwrap();
+            if res == 0 {
+                panic!("make_not_current failed")
+            }
+        })
     }
 
     pub fn get_proc_address(&self, symbol: &str) -> *const c_void {
@@ -160,9 +204,12 @@ impl GlContext {
     }
 
     pub fn swap_buffers(&self) {
-        unsafe {
-            glx::glXSwapBuffers(self.display, self.window);
-        }
+        errors::XErrorHandler::handle(self.display, |error_handler| {
+            unsafe {
+                glx::glXSwapBuffers(self.display, self.window);
+            }
+            error_handler.check().unwrap();
+        })
     }
 }
 

--- a/src/x11/errors.rs
+++ b/src/x11/errors.rs
@@ -1,0 +1,131 @@
+use std::ffi::CStr;
+use std::fmt::{Debug, Formatter};
+use x11::xlib;
+
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Mutex;
+
+static CURRENT_ERROR_PTR: AtomicPtr<Mutex<Option<xlib::XErrorEvent>>> =
+    AtomicPtr::new(::std::ptr::null_mut());
+
+/// A helper struct for safe X11 error handling
+pub struct XErrorHandler<'a> {
+    display: *mut xlib::Display,
+    mutex: &'a Mutex<Option<xlib::XErrorEvent>>,
+}
+
+impl<'a> XErrorHandler<'a> {
+    /// Syncs and checks if any previous X11 calls returned an error
+    pub fn check(&mut self) -> Result<(), XLibError> {
+        // Flush all possible previous errors
+        unsafe {
+            xlib::XSync(self.display, 0);
+        }
+        let error = self.mutex.lock().unwrap().take();
+
+        match error {
+            None => Ok(()),
+            Some(inner) => Err(XLibError { inner }),
+        }
+    }
+
+    /// Sets up a temporary X11 error handler for the duration of the given closure, and allows
+    /// that closure to check on the latest X11 error at any time
+    pub fn handle<T, F: FnOnce(&mut XErrorHandler) -> T>(
+        display: *mut xlib::Display,
+        handler: F,
+    ) -> T {
+        unsafe extern "C" fn error_handler(
+            _dpy: *mut xlib::Display,
+            err: *mut xlib::XErrorEvent,
+        ) -> i32 {
+            // SAFETY: the error pointer should be safe to copy
+            let err = *err;
+            // SAFETY: the ptr can only point to a valid instance or be null
+            let mutex = CURRENT_ERROR_PTR.load(Ordering::SeqCst).as_ref();
+            let mutex = if let Some(mutex) = mutex {
+                mutex
+            } else {
+                return 2;
+            };
+
+            match mutex.lock() {
+                Ok(mut current_error) => {
+                    *current_error = Some(err);
+                    0
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[FATAL] raw-gl-context: Failed to lock for X11 Error Handler: {:?}",
+                        e
+                    );
+                    1
+                }
+            }
+        }
+
+        // Flush all possible previous errors
+        unsafe {
+            xlib::XSync(display, 0);
+        }
+
+        let mut mutex = Mutex::new(None);
+        CURRENT_ERROR_PTR.store(&mut mutex, Ordering::SeqCst);
+
+        let old_handler = unsafe { xlib::XSetErrorHandler(Some(error_handler)) };
+        let panic_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let mut h = XErrorHandler {
+                display,
+                mutex: &mutex,
+            };
+            handler(&mut h)
+        }));
+        // Whatever happened, restore old error handler
+        unsafe { xlib::XSetErrorHandler(old_handler) };
+        CURRENT_ERROR_PTR.store(::core::ptr::null_mut(), Ordering::SeqCst);
+
+        match panic_result {
+            Ok(v) => v,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+}
+
+pub struct XLibError {
+    inner: xlib::XErrorEvent,
+}
+
+impl XLibError {
+    pub fn get_display_name(&self, buf: &mut [u8]) -> &CStr {
+        unsafe {
+            xlib::XGetErrorText(
+                self.inner.display,
+                self.inner.error_code.into(),
+                buf.as_mut_ptr().cast(),
+                (buf.len() - 1) as i32,
+            );
+        }
+
+        *buf.last_mut().unwrap() = 0;
+        // SAFETY: whatever XGetErrorText did or not, we guaranteed there is a nul byte at the end of the buffer
+        unsafe { CStr::from_ptr(buf.as_mut_ptr().cast()) }
+    }
+}
+
+impl Debug for XLibError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut buf = [0; 255];
+        let display_name = self.get_display_name(&mut buf).to_string_lossy();
+
+        f.debug_struct("XLibError")
+            .field("error_code", &self.inner.error_code)
+            .field("error_message", &display_name)
+            .field("minor_code", &self.inner.minor_code)
+            .field("request_code", &self.inner.request_code)
+            .field("type", &self.inner.type_)
+            .field("resource_id", &self.inner.resourceid)
+            .field("serial", &self.inner.serial)
+            .finish()
+    }
+}


### PR DESCRIPTION
This PR adds some infrastructure to handle errors that can be raised when making X11 API calls:

* Adds a private, platform-specific field to `GlError::CreationFailed` for implementations to add more information on the source of the failure for debugging. This is just an empty tuple for on non-X11 for now. **This is a breaking change**, as this breaks enum exhaustiveness.
* Adds an `XLibError` helper struct, with a `Debug` implementation showing the text version of the error using `XGetErrorText`, to help debugging when using `unwrap()`.
* Adds an `XErrorHandler` helper struct, which helps setup a temporary error handler for the duration of a given closure (after which the previous error handler is restored, which is needed for embedding). It also ensures the error handler is properly restored after an early return or a panic.